### PR TITLE
Add missing property for systools

### DIFF
--- a/ebin/entop.app
+++ b/ebin/entop.app
@@ -3,4 +3,5 @@
   {vsn, "0.0.1"},
   {modules, [entop,  entop_collector, entop_format, entop_view, entop_net]},
   {applications, []},
+  {registered, []},
   {env, []}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [fail_on_warning, debug_info]}.
 {deps_dir, "deps"}.
 {clean_files, ["ebin/*.beam"]}.
-{deps, [{cecho, ".*", {git, "https://github.com/mazenharake/cecho.git", "HEAD"}}]}.
+{deps, [{cecho, ".*", {git, "https://github.com/systra/cecho.git", "HEAD"}}]}.
 {escript_name, "rebar_tmp"}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [fail_on_warning, debug_info]}.
 {deps_dir, "deps"}.
 {clean_files, ["ebin/*.beam"]}.
-{deps, [{cecho, ".*", {git, "https://github.com/systra/cecho.git", "HEAD"}}]}.
+{deps, [{cecho, ".*", {git, "https://github.com/mazenharake/cecho.git", "HEAD"}}]}.
 {escript_name, "rebar_tmp"}.


### PR DESCRIPTION
When using OTP tools (systools) to build application release the following error occurs:

`Missing parameter in .app file: registered`

Adding the `registered` property to the entop.app file fixes this (only first commit is required).
